### PR TITLE
Adding support to shared tables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum>=1.2.0<2.0.0',
         'singer-python>=5.12.2<6.0.0',
         'backoff>=1.3.2<2.0.0',
-        'psycopg2>=2.9.3<3.0.0',
+        'psycopg2-binary>=2.9.3<2.9.5',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         'pendulum>=1.2.0<2.0.0',
         'singer-python>=5.12.2<6.0.0',
         'backoff>=1.3.2<2.0.0',
-        'psycopg2-binary>=2.9.3<2.9.5',
+        'psycopg2-binary>=2.9.3<3.0.0',
       ],
       setup_requires=[
         'pytest-runner>=2.11,<3.0a',

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -54,12 +54,15 @@ STRING_TYPES = {'char', 'character', 'nchar', 'bpchar', 'text', 'varchar',
 
 BYTES_FOR_INTEGER_TYPE = {
     'int2': 2,
+    'smallint': 2,
     'int': 4,
     'int4': 4,
-    'int8': 8
+    'integer': 4,
+    'int8': 8,
+    'bigint': 8
 }
 
-FLOAT_TYPES = {'float', 'float4', 'float8'}
+FLOAT_TYPES = {'float', 'float4', 'float8', 'double precision', 'real'}
 
 DATE_TYPES = {'date'}
 
@@ -164,7 +167,7 @@ def schema_for_column(c):
     inclusion = 'available'
     result = Schema(inclusion=inclusion)
 
-    if column_type == 'bool':
+    if column_type in ('bool', 'boolean'):
         result.type = 'boolean'
 
     elif column_type in BYTES_FOR_INTEGER_TYPE:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -76,20 +76,20 @@ def discover_catalog(conn, db_schema):
         conn,
         """
         SELECT table_name, table_type
-        FROM INFORMATION_SCHEMA.Tables
-        WHERE table_schema = '{}'
+        FROM SVV_ALL_TABLES
+        WHERE schema_name = '{}'
         """.format(db_schema))
 
     column_specs = select_all(
         conn,
         """
-        SELECT c.table_name, c.ordinal_position, c.column_name, c.udt_name,
+        SELECT c.table_name, c.ordinal_position, c.column_name, c.data_type,
         c.is_nullable
-        FROM INFORMATION_SCHEMA.Tables t
-        JOIN INFORMATION_SCHEMA.Columns c
+        FROM SVV_ALL_TABLES t
+        JOIN SVV_ALL_COLUMNS c
             ON c.table_name = t.table_name AND
-               c.table_schema = t.table_schema
-        WHERE t.table_schema = '{}'
+               c.schema_name = t.schema_name
+        WHERE t.schema_name = '{}'
         ORDER BY c.table_name, c.ordinal_position
         """.format(db_schema))
 
@@ -156,6 +156,7 @@ def do_discover(conn, db_schema):
     LOGGER.info("Completed discover")
 
 
+# TODO: need to review after adding changing the columns table
 def schema_for_column(c):
     '''Returns the Schema object for the given Column.'''
     column_type = c['type'].lower()

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -159,7 +159,6 @@ def do_discover(conn, db_schema):
     LOGGER.info("Completed discover")
 
 
-# TODO: need to review after adding changing the columns table
 def schema_for_column(c):
     '''Returns the Schema object for the given Column.'''
     column_type = c['type'].lower()


### PR DESCRIPTION
The Redshift extractor works by first discovering what tables and views are available to sync. This is done by querying information_schema to get table names, columns, etc. However, metadata on shared table views are not available so the extractor fails. Additionally, shared table is set up in its own database on Redshift and we cannot connect to it directly.

```
Cannot connect to shared database "...". Connect to the databases in your cluster instead and use cross-database query notation .
```

So in this PR we are replacing the `INFORMATION_SCHEMA.Tables` by `SVV_ALL_TABLES` and replacing `INFORMATION_SCHEMA.Columns` by `SVV_ALL_COLUMNS` that shows shared table information.

The only limitation that we still have is that we still didn't get the table constraints/PKs for shared tables.