### PR TITLE
Add LIMIT and OFFSET option to allow extract data in batches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Example:
         "password": "REDSHIFT_PASSWORD",
         "start_date": "REDSHIFT_START_DATE",
         "schema": "REDSHIFT_SCHEMA",
-        "limit_rows_per_batch": "REDSHIFT_LIMIT_ROWS_PER_BATCH"
+        "limit_rows_per_batch": "REDSHIFT_LIMIT_ROWS_PER_BATCH",
     }
 
 
@@ -223,6 +223,10 @@ Example (paired with ``target-datadotworld``)
     If your table is too big to fit in memory at once where the extractor is running, you should consider using the ``limit_rows_per_batch``
     that limits the number of rows extracted in a single query. This option uses the LIMIT and OFFSET options to extract
     the same number of rows for each query until there is no more data to extract.
+
+    When using the ``limit_rows_per_batch`` you should consider using the ``extra-order-by-columns`` to add more columns
+    (e.g. ``"col1"`` or ``"col1,col2,col3"``) during the ordination step to avoid the random behavior for rows with the same ``replication-key``
+    which could cause ingesting duplicate records and also miss some records.
 
 Step 4: Sync your data
 ----------------------

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ The json file requires the following attributes;
 And an optional attribute;
 
 * ``schema``
+* ``limit_rows_per_batch``
 
 Example:
 
@@ -47,7 +48,8 @@ Example:
         "user": "REDSHIFT_USER",
         "password": "REDSHIFT_PASSWORD",
         "start_date": "REDSHIFT_START_DATE",
-        "schema": "REDSHIFT_SCHEMA"
+        "schema": "REDSHIFT_SCHEMA",
+        "limit_rows_per_batch": "REDSHIFT_LIMIT_ROWS_PER_BATCH"
     }
 
 
@@ -216,6 +218,11 @@ Example (paired with ``target-datadotworld``)
 
     tap-redshift -c config.json --catalog catalog.json | target-datadotworld -c config-dw.json
 
+.. note::
+
+    If your table is too big to fit at once where the extractor is running, you should consider using the ``limit_rows_per_batch``
+    that limits the number of rows extracted in a single query. This option uses the LIMIT and OFFSET options to extract
+    the same number of rows for each query until there is no more data to extract.
 
 Step 4: Sync your data
 ----------------------

--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,7 @@ Example (paired with ``target-datadotworld``)
 
 .. note::
 
-    If your table is too big to fit at once where the extractor is running, you should consider using the ``limit_rows_per_batch``
+    If your table is too big to fit in memory at once where the extractor is running, you should consider using the ``limit_rows_per_batch``
     that limits the number of rows extracted in a single query. This option uses the LIMIT and OFFSET options to extract
     the same number of rows for each query until there is no more data to extract.
 

--- a/README.rst
+++ b/README.rst
@@ -224,7 +224,7 @@ Example (paired with ``target-datadotworld``)
     that limits the number of rows extracted in a single query. This option uses the LIMIT and OFFSET options to extract
     the same number of rows for each query until there is no more data to extract.
 
-    When using the ``limit_rows_per_batch`` you should consider using the ``extra-order-by-columns`` to add more columns
+    When using the ``limit_rows_per_batch`` you should consider using the ``extra-order-by-columns`` (in Metadata) to add more columns
     (e.g. ``"col1"`` or ``"col1,col2,col3"``) during the ordination step to avoid the random behavior for rows with the same ``replication-key``
     which could cause ingesting duplicate records and also miss some records.
 

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -403,11 +403,11 @@ def sync_table(connection, catalog_entry, state, limit):
                 if not limit:
                     more_records = False
                 else:
+                    params['offset'] += params['limit']
                     row = execute_query(cursor, select, params)
                     if not row:
                         more_records = False
-                    else:
-                        params['offset'] += params['limit']
+
 
         if not replication_key:
             yield activate_version_message

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -535,7 +535,7 @@ def main_impl():
     connection = open_connection(args.config)
     db_schema = args.config.get('schema', 'public')
     db_name = args.config.get('dbname', 'dev')
-    limit = args.config.get('limit_rows_per_batch', None)
+    limit = args.config.get('limit_rows_per_batch')
     if args.discover:
         do_discover(connection, db_name, db_schema)
     elif args.catalog:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -27,7 +27,6 @@ import sys
 import simplejson as json
 
 import psycopg2
-from psycopg2 import errors
 import singer
 import singer.metrics as metrics
 from singer import metadata
@@ -421,11 +420,7 @@ def sync_table(connection, catalog_entry, state, limit):
 def execute_query(cursor, select, params):
     query_string = cursor.mogrify(select, params)
     LOGGER.info('Running {}'.format(query_string))
-    try:
-        cursor.execute(select, params)
-    except errors.InternalError_ as e:
-        LOGGER.error(f'Error during executing query ({e.pgerror}) it will retry.')
-        cursor.execute(select, params)
+    cursor.execute(select, params)
     row = cursor.fetchone()
     return row
 

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -27,6 +27,7 @@ import sys
 import simplejson as json
 
 import psycopg2
+from psycopg2 import errors
 import singer
 import singer.metrics as metrics
 from singer import metadata
@@ -420,7 +421,11 @@ def sync_table(connection, catalog_entry, state, limit):
 def execute_query(cursor, select, params):
     query_string = cursor.mogrify(select, params)
     LOGGER.info('Running {}'.format(query_string))
-    cursor.execute(select, params)
+    try:
+        cursor.execute(select, params)
+    except errors.InternalError_ as e:
+        LOGGER.error(f'Error during executing query ({e.pgerror}) it will retry.')
+        cursor.execute(select, params)
     row = cursor.fetchone()
     return row
 

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -306,123 +306,141 @@ def sync_table(connection, catalog_entry, state, limit):
 
     tap_stream_id = catalog_entry.tap_stream_id
     LOGGER.info('Beginning sync for {} table'.format(tap_stream_id))
-    with connection.cursor() as cursor:
-        schema, table = catalog_entry.table.split('.')
-        database = catalog_entry.database
-        select = 'SELECT {} FROM {}.{}.{}'.format(
-            ','.join('"{}"'.format(c) for c in columns),
-            '"{}"'.format(database),
-            '"{}"'.format(schema),
-            '"{}"'.format(table))
-        params = {}
 
-        if start_date is not None:
-            formatted_start_date = datetime.datetime.strptime(
-                start_date, '%Y-%m-%dT%H:%M:%SZ').astimezone()
+    schema, table = catalog_entry.table.split('.')
+    database = catalog_entry.database
+    select = 'SELECT {} FROM {}.{}.{}'.format(
+        ','.join(columns),
+        '"{}"'.format(database),
+        '"{}"'.format(schema),
+        '"{}"'.format(table))
+    params = {}
 
-        replication_key = metadata.to_map(catalog_entry.metadata).get(
-            (), {}).get('replication-key')
-        replication_key_value = None
-        bookmark_is_empty = state.get('bookmarks', {}).get(
-            tap_stream_id) is None
-        stream_version = get_stream_version(tap_stream_id, state)
-        state = singer.write_bookmark(
+    if start_date is not None:
+        formatted_start_date = datetime.datetime.strptime(
+            start_date, '%Y-%m-%dT%H:%M:%SZ').astimezone()
+
+    extra_order_by_columns = metadata.to_map(catalog_entry.metadata).get(
+        (), {}).get('extra-order-by-columns', None)
+    replication_key = metadata.to_map(catalog_entry.metadata).get(
+        (), {}).get('replication-key')
+    replication_key_value = None
+    bookmark_is_empty = state.get('bookmarks', {}).get(
+        tap_stream_id) is None
+    stream_version = get_stream_version(tap_stream_id, state)
+    state = singer.write_bookmark(
+        state,
+        tap_stream_id,
+        'version',
+        stream_version
+    )
+    activate_version_message = singer.ActivateVersionMessage(
+        stream=catalog_entry.stream,
+        version=stream_version
+    )
+
+    # If there's a replication key, we want to emit an ACTIVATE_VERSION
+    # message at the beginning so the records show up right away. If
+    # there's no bookmark at all for this stream, assume it's the very
+    # first replication. That is, clients have never seen rows for this
+    # stream before, so they can immediately acknowledge the present
+    # version.
+    if replication_key or bookmark_is_empty:
+        yield activate_version_message
+
+    if replication_key:
+        replication_key_value = singer.get_bookmark(
             state,
             tap_stream_id,
-            'version',
-            stream_version
-        )
-        activate_version_message = singer.ActivateVersionMessage(
-            stream=catalog_entry.stream,
-            version=stream_version
-        )
+            'replication_key_value'
+        ) or formatted_start_date.isoformat()
 
-        # If there's a replication key, we want to emit an ACTIVATE_VERSION
-        # message at the beginning so the records show up right away. If
-        # there's no bookmark at all for this stream, assume it's the very
-        # first replication. That is, clients have never seen rows for this
-        # stream before, so they can immediately acknowledge the present
-        # version.
-        if replication_key or bookmark_is_empty:
-            yield activate_version_message
+    if replication_key_value is not None:
+        entry_schema = catalog_entry.schema
 
-        if replication_key:
-            replication_key_value = singer.get_bookmark(
-                state,
-                tap_stream_id,
-                'replication_key_value'
-            ) or formatted_start_date.isoformat()
+        if entry_schema.properties[replication_key].format == 'date-time':
+            replication_key_value = pendulum.parse(replication_key_value)
 
-        if replication_key_value is not None:
-            entry_schema = catalog_entry.schema
+        select += f' WHERE {replication_key} >= %(replication_key_value)s '
+        order_by_columns = f'{replication_key},{extra_order_by_columns}' \
+            if extra_order_by_columns else replication_key
+        select += f'ORDER BY {order_by_columns} ASC '
+        params['replication_key_value'] = replication_key_value
 
-            if entry_schema.properties[replication_key].format == 'date-time':
-                replication_key_value = pendulum.parse(replication_key_value)
+    elif replication_key is not None:
+        order_by_columns = f'{replication_key},{extra_order_by_columns}' \
+            if extra_order_by_columns else replication_key
+        select += f' ORDER BY {order_by_columns} ASC '
 
-            select += ' WHERE {} >= %(replication_key_value)s ORDER BY {} ' \
-                      'ASC'.format(replication_key, replication_key)
-            params['replication_key_value'] = replication_key_value
+    if limit:
+        select += ' LIMIT %(limit)s OFFSET %(offset)s'
+        params['limit'] = limit
+        params['offset'] = 0
 
-        elif replication_key is not None:
-            select += ' ORDER BY {} ASC'.format(replication_key)
+    with metrics.record_counter(None) as counter:
+        counter.tags['database'] = catalog_entry.database
+        counter.tags['table'] = catalog_entry.table
+        rows_saved = 0
+        time_extracted = utils.now()
+        more_records = True
 
-        if limit:
-            select += ' LIMIT %(limit)s OFFSET %(offset)s'
-            params['limit'] = limit
-            params['offset'] = 0
+        row, cursor, connection = execute_query(connection, None, select, params)
 
-        with metrics.record_counter(None) as counter:
-            counter.tags['database'] = catalog_entry.database
-            counter.tags['table'] = catalog_entry.table
-            rows_saved = 0
-            time_extracted = utils.now()
-            more_records = True
+        while more_records:
+            while row:
+                counter.increment()
+                rows_saved += 1
+                record_message = row_to_record(catalog_entry,
+                                               stream_version,
+                                               row,
+                                               columns,
+                                               time_extracted)
+                yield record_message
 
-            row = execute_query(cursor, select, params)
+                if replication_key is not None and record_message.record[replication_key] is not None:
+                    state = singer.write_bookmark(state,
+                                                  tap_stream_id,
+                                                  'replication_key_value',
+                                                  record_message.record[replication_key])
+                if rows_saved % 1000 == 0:
+                    yield singer.StateMessage(value=copy.deepcopy(state))
+                row = cursor.fetchone()
 
-            while more_records:
-                while row:
-                    counter.increment()
-                    rows_saved += 1
-                    record_message = row_to_record(catalog_entry,
-                                                   stream_version,
-                                                   row,
-                                                   columns,
-                                                   time_extracted)
-                    yield record_message
-
-                    if replication_key is not None:
-                        state = singer.write_bookmark(state,
-                                                      tap_stream_id,
-                                                      'replication_key_value',
-                                                      record_message.record[replication_key])
-                    if rows_saved % 1000 == 0:
-                        yield singer.StateMessage(value=copy.deepcopy(state))
-                    row = cursor.fetchone()
-
-                if not limit:
+            if not limit:
+                more_records = False
+            else:
+                params['offset'] += params['limit']
+                row, cursor, connection = execute_query(connection, cursor, select, params)
+                if not row:
                     more_records = False
-                else:
-                    params['offset'] += params['limit']
-                    row = execute_query(cursor, select, params)
-                    if not row:
-                        more_records = False
+
+    if cursor and not cursor.closed:
+        cursor.close()
+
+    if not replication_key:
+        yield activate_version_message
+        state = singer.write_bookmark(state, catalog_entry.tap_stream_id,
+                                      'version', None)
+
+    yield singer.StateMessage(value=copy.deepcopy(state))
 
 
-        if not replication_key:
-            yield activate_version_message
-            state = singer.write_bookmark(state, catalog_entry.tap_stream_id,
-                                          'version', None)
-
-        yield singer.StateMessage(value=copy.deepcopy(state))
-
-
-def execute_query(cursor, select, params):
+def execute_query(connection, cursor, select, params):
+    if cursor and not cursor.closed:
+        cursor.close()
+    cursor = connection.cursor()
     query_string = cursor.mogrify(select, params)
     LOGGER.info('Running {}'.format(query_string))
-    cursor.execute(select, params)
+    try:
+        cursor.execute(select, params)
+    except Exception as e:
+        LOGGER.error(f'Failure during query: {str(e)}')
+        LOGGER.info('Trying to reconnect')
+        connection = open_connection(CONFIG)
+        cursor = connection.cursor()
+        cursor.execute(select, params)
     row = cursor.fetchone()
-    return row
+    return row, cursor, connection
 
 
 def generate_messages(conn, db_name, db_schema, catalog, state, limit):

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -405,6 +405,9 @@ def sync_table(connection, catalog_entry, state, limit):
                         yield singer.StateMessage(value=copy.deepcopy(state))
                     row = cursor.fetchone()
 
+            if limit <= 0:
+                break
+
             params['offset'] += params['limit']
 
         if not replication_key:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -525,7 +525,7 @@ def main_impl():
     connection = open_connection(args.config)
     db_schema = args.config.get('schema', 'public')
     db_name = args.config.get('dbname', 'dev')
-    limit = args.config.get('limit_rows', -1)
+    limit = args.config.get('limit_rows_per_batch', -1)
     if args.discover:
         do_discover(connection, db_name, db_schema)
     elif args.catalog:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,7 @@ def column_specs_cursor():
 def expected_catalog_from_db():
     return Catalog.from_dict({'streams': [
         {'tap_stream_id': 'test-db.public.table1',
+         'database_name': 'test-db',
          'table_name': 'public.table1',
          'schema': {
              'properties': {
@@ -139,6 +140,7 @@ def expected_catalog_from_db():
                            'inclusion': 'available'}}
          ]},
         {'tap_stream_id': 'test-db.public.table2',
+         'database_name': 'test-db',
          'table_name': 'public.table2',
          'schema': {
              'properties': {
@@ -173,6 +175,7 @@ def expected_catalog_from_db():
                            'sql-datatype': 'bool',
                            'inclusion': 'available'}}]},
         {'tap_stream_id': 'test-db.public.view1',
+         'database_name': 'test-db',
          'table_name': 'public.view1',
          'schema': {
              'properties': {

--- a/tests/tap_redshift/test_tap_redshift.py
+++ b/tests/tap_redshift/test_tap_redshift.py
@@ -201,8 +201,7 @@ expected_result = {
 
 class TestRedShiftTap(object):
     def test_discover_catalog(self, discovery_conn, expected_catalog_from_db):
-        actual_catalog = tap_redshift.discover_catalog(discovery_conn,
-                                                       'public')
+        actual_catalog = tap_redshift.discover_catalog(discovery_conn, 'test-db', 'public')
         for i, actual_entry in enumerate(actual_catalog.streams):
 
             expected_entry = expected_catalog_from_db.streams[i]
@@ -309,8 +308,7 @@ class TestRedShiftTap(object):
         assert_that(column_schema, equal_to(expected_schema))
 
     def test_table_metadata(self, discovery_conn, expected_catalog_from_db):
-        actual_catalog = tap_redshift.discover_catalog(discovery_conn,
-                                                       'public')
+        actual_catalog = tap_redshift.discover_catalog(discovery_conn, 'test-db', 'public')
         for i, actual_entry in enumerate(actual_catalog.streams):
             expected_entry = expected_catalog_from_db.streams[i]
             actual_metadata = metadata.to_map(actual_entry.metadata)


### PR DESCRIPTION
The `tap-redshift` pulls all data in a table at once (in the first extraction), and it could use too much memory causing OOM in the edge cases.

This change includes the option to define a limit and set the `LIMIT` and `OFFSET` in the query to extract the data in batches to avoid storing too much data in memory.