### PR TITLE
Allow `extra-order-by-columns` to be used in full sync

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -370,7 +370,7 @@ def sync_table(connection, catalog_entry, state, limit):
     if extra_order_by_columns:
         order_by_columns.append(extra_order_by_columns)
     if order_by_columns:
-        select += f' ORDER BY {",".join(order_by_columns)} ASC '
+        select += f' ORDER BY {",".join(order_by_columns)} '
 
     if limit:
         select += ' LIMIT %(limit)s OFFSET %(offset)s'

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -362,15 +362,15 @@ def sync_table(connection, catalog_entry, state, limit):
             replication_key_value = pendulum.parse(replication_key_value)
 
         select += f' WHERE {replication_key} >= %(replication_key_value)s '
-        order_by_columns = f'{replication_key},{extra_order_by_columns}' \
-            if extra_order_by_columns else replication_key
-        select += f'ORDER BY {order_by_columns} ASC '
         params['replication_key_value'] = replication_key_value
 
-    elif replication_key is not None:
-        order_by_columns = f'{replication_key},{extra_order_by_columns}' \
-            if extra_order_by_columns else replication_key
-        select += f' ORDER BY {order_by_columns} ASC '
+    order_by_columns = []
+    if replication_key:
+        order_by_columns.append(replication_key)
+    if extra_order_by_columns:
+        order_by_columns.append(extra_order_by_columns)
+    if order_by_columns:
+        select += f' ORDER BY {",".join(order_by_columns)} ASC '
 
     if limit:
         select += ' LIMIT %(limit)s OFFSET %(offset)s'


### PR DESCRIPTION
The `extra-order-by-columns` was being added only in incremental tables, this change allows using the `extra-order-by-columns` also with full sync which is required when using the limit option.