### PR TITLE
Fix: Avoiding removing/clearing the state of a stream that is not in catalog anymore

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -501,7 +501,7 @@ def do_sync(conn, db_name, db_schema, catalog, state, limit):
 def build_state(raw_state, catalog):
     LOGGER.info('Building State from raw state {}'.format(raw_state))
 
-    state = {}
+    state = raw_state
 
     currently_syncing = singer.get_currently_syncing(raw_state)
     if currently_syncing:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -477,6 +477,7 @@ def generate_messages(conn, db_name, db_schema, catalog, state, limit):
 
     # If we get here, we've finished processing all the streams, so clear
     # currently_syncing from the state and emit a state message.
+    LOGGER.info(f'Last states: {state}')
     state = singer.set_currently_syncing(state, None)
     yield singer.StateMessage(value=copy.deepcopy(state))
 

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -477,7 +477,6 @@ def generate_messages(conn, db_name, db_schema, catalog, state, limit):
 
     # If we get here, we've finished processing all the streams, so clear
     # currently_syncing from the state and emit a state message.
-    LOGGER.info(f'Last states: {state}')
     state = singer.set_currently_syncing(state, None)
     yield singer.StateMessage(value=copy.deepcopy(state))
 

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -100,10 +100,8 @@ def resolve_catalog(discovered, catalog, state):
     for catalog_entry in streams:
         discovered_table = discovered.get_stream(catalog_entry.tap_stream_id)
         if not discovered_table:
-            LOGGER.warning('Database {} table {} selected but does not exist'
-                           .format(catalog_entry.database,
-                                   catalog_entry.table))
-            continue
+            raise Exception(f'Database {catalog_entry.database} table {catalog_entry.table} '
+                            'selected but does not exist')
         selected = get_selected_properties(catalog_entry)
 
         # These are the columns we need to select

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -100,8 +100,10 @@ def resolve_catalog(discovered, catalog, state):
     for catalog_entry in streams:
         discovered_table = discovered.get_stream(catalog_entry.tap_stream_id)
         if not discovered_table:
-            raise Exception(f'Database {catalog_entry.database} table {catalog_entry.table} '
-                            'selected but does not exist')
+            LOGGER.warning('Database {} table {} selected but does not exist'
+                           .format(catalog_entry.database,
+                                   catalog_entry.table))
+            continue
         selected = get_selected_properties(catalog_entry)
 
         # These are the columns we need to select

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,7 +216,7 @@ def incremental_catalog():
         'streams': [{
             'database_name': 'FakeDB',
             'table_name': 'category',
-            'tap_stream_id': 'dev-category',
+            'tap_stream_id': 'existing_stream',
             'is_view': False,
             'stream': 'category',
             'schema': {
@@ -243,7 +243,7 @@ def incremental_catalog():
             {
                 'database_name': 'FakeDB',
                 'table_name': 'category',
-                'tap_stream_id': 'dev-category2',
+                'tap_stream_id': 'included_stream',
                 'is_view': False,
                 'stream': 'category',
                 'schema': {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,29 +213,30 @@ def expected_catalog_from_db():
 @pytest.fixture()
 def incremental_catalog():
     return Catalog.from_dict({
-        'streams': [{
-            'database_name': 'FakeDB',
-            'table_name': 'table1',
-            'tap_stream_id': 'existing_stream',
-            'is_view': False,
-            'stream': 'category',
-            'schema': {
-                'type': 'object',
-                'properties': {
-                    'id': {'type': 'integer',},
-                    'create_at': {'type': 'string',}
-                }
-            },
-            'metadata': [
-                {
-                    'breadcrumb': (),
-                    'metadata': {
-                        'replication-method': 'INCREMENTAL',
-                        'replication-key': 'create_at'
+        'streams': [
+            {
+                'database_name': 'FakeDB',
+                'table_name': 'table1',
+                'tap_stream_id': 'existing_stream',
+                'is_view': False,
+                'stream': 'category',
+                'schema': {
+                    'type': 'object',
+                    'properties': {
+                        'id': {'type': 'integer', },
+                        'create_at': {'type': 'string', }
                     }
                 },
-            ]
-        },
+                'metadata': [
+                    {
+                        'breadcrumb': (),
+                        'metadata': {
+                            'replication-method': 'INCREMENTAL',
+                            'replication-key': 'create_at'
+                        }
+                    },
+                ]
+            },
             {
                 'database_name': 'FakeDB',
                 'table_name': 'table2',
@@ -245,8 +246,8 @@ def incremental_catalog():
                 'schema': {
                     'type': 'object',
                     'properties': {
-                        'id': {'type': 'integer',},
-                        'updated_at': {'type': 'string',}
+                        'id': {'type': 'integer', },
+                        'updated_at': {'type': 'string', }
                     }
                 },
                 'metadata': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,19 +215,15 @@ def incremental_catalog():
     return Catalog.from_dict({
         'streams': [{
             'database_name': 'FakeDB',
-            'table_name': 'category',
+            'table_name': 'table1',
             'tap_stream_id': 'existing_stream',
             'is_view': False,
             'stream': 'category',
             'schema': {
                 'type': 'object',
                 'properties': {
-                    'id': {
-                        'type': 'integer',
-                    },
-                    'create_at': {
-                        'type': 'string',
-                    }
+                    'id': {'type': 'integer',},
+                    'create_at': {'type': 'string',}
                 }
             },
             'metadata': [
@@ -242,19 +238,15 @@ def incremental_catalog():
         },
             {
                 'database_name': 'FakeDB',
-                'table_name': 'category',
+                'table_name': 'table2',
                 'tap_stream_id': 'included_stream',
                 'is_view': False,
                 'stream': 'category',
                 'schema': {
                     'type': 'object',
                     'properties': {
-                        'id': {
-                            'type': 'integer',
-                        },
-                        'updated_at': {
-                            'type': 'string',
-                        }
+                        'id': {'type': 'integer',},
+                        'updated_at': {'type': 'string',}
                     }
                 },
                 'metadata': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,6 +211,67 @@ def expected_catalog_from_db():
 
 
 @pytest.fixture()
+def incremental_catalog():
+    return Catalog.from_dict({
+        'streams': [{
+            'database_name': 'FakeDB',
+            'table_name': 'category',
+            'tap_stream_id': 'dev-category',
+            'is_view': False,
+            'stream': 'category',
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'id': {
+                        'type': 'integer',
+                    },
+                    'create_at': {
+                        'type': 'string',
+                    }
+                }
+            },
+            'metadata': [
+                {
+                    'breadcrumb': (),
+                    'metadata': {
+                        'replication-method': 'INCREMENTAL',
+                        'replication-key': 'create_at'
+                    }
+                },
+            ]
+        },
+            {
+                'database_name': 'FakeDB',
+                'table_name': 'category',
+                'tap_stream_id': 'dev-category2',
+                'is_view': False,
+                'stream': 'category',
+                'schema': {
+                    'type': 'object',
+                    'properties': {
+                        'id': {
+                            'type': 'integer',
+                        },
+                        'updated_at': {
+                            'type': 'string',
+                        }
+                    }
+                },
+                'metadata': [
+                    {
+                        'breadcrumb': (),
+                        'metadata': {
+                            'replication-method': 'INCREMENTAL',
+                            'replication-key': 'updated_at'
+                        }
+                    },
+                ]
+            }
+        ]
+    })
+
+
+@pytest.fixture()
 def expected_catalog_discovered():
     return Catalog.from_dict({
         'streams': [{

--- a/tests/tap_redshift/test_resolve.py
+++ b/tests/tap_redshift/test_resolve.py
@@ -60,14 +60,19 @@ class TestResolve(object):
         assert_that(get_selected_properties(entry), equal_to(expected))
 
     def test_build_state(self, incremental_catalog):
+        """
+        Test if the state is built correctly from the catalog and initial state:
+         - keeping the existing streams state even if they are not in the catalog anymore.
+         - adding the streams that are in the catalog but not in the state.
+         """
         initial_state = {'bookmarks':
-                             {'dev-category': {'replication_key': 'create_at', 'replication_key_value': '2022-01-01T00:00:00Z'},
+                             {'existing_stream': {'replication_key': 'create_at', 'replication_key_value': '2022-01-01T00:00:00Z'},
                               'non_existing_stream': {'replication_key': 'updated_at', 'replication_key_value': '2023-01-01T00:00:00Z'}}}
 
         expected_state = {'bookmarks':
-                              {'dev-category': {'replication_key': 'create_at', 'replication_key_value': '2022-01-01T00:00:00Z'},
+                              {'existing_stream': {'replication_key': 'create_at', 'replication_key_value': '2022-01-01T00:00:00Z'},
                                'non_existing_stream': {'replication_key': 'updated_at', 'replication_key_value': '2023-01-01T00:00:00Z'},
-                               'dev-category2': {'replication_key': 'updated_at', 'replication_key_value': None}}}
+                               'included_stream': {'replication_key': 'updated_at', 'replication_key_value': None}}}
 
         state = tap_redshift.build_state(initial_state, incremental_catalog)
 

--- a/tests/tap_redshift/test_resolve.py
+++ b/tests/tap_redshift/test_resolve.py
@@ -59,6 +59,21 @@ class TestResolve(object):
         entry, expected = selectable_properties_param
         assert_that(get_selected_properties(entry), equal_to(expected))
 
+    def test_build_state(self, incremental_catalog):
+        initial_state = {'bookmarks':
+                             {'dev-category': {'replication_key': 'create_at', 'replication_key_value': '2022-01-01T00:00:00Z'},
+                              'non_existing_stream': {'replication_key': 'updated_at', 'replication_key_value': '2023-01-01T00:00:00Z'}}}
+
+        expected_state = {'bookmarks':
+                              {'dev-category': {'replication_key': 'create_at', 'replication_key_value': '2022-01-01T00:00:00Z'},
+                               'non_existing_stream': {'replication_key': 'updated_at', 'replication_key_value': '2023-01-01T00:00:00Z'},
+                               'dev-category2': {'replication_key': 'updated_at', 'replication_key_value': None}}}
+
+        state = tap_redshift.build_state(initial_state, incremental_catalog)
+
+        assert_that(state, equal_to(expected_state))
+
+
     def test_resolve_catalog(
             self, expected_catalog_discovered, resolvable_catalog_param):
         catalog, streams_and_properties = resolvable_catalog_param


### PR DESCRIPTION
If a table is missing (or temporarily unavailable), When the state is built, the state for the missing table is removed which makes the state to be lost even if this table is re-added or is available in a next sync.

- Tests:
Included the `test_build_state` to validate all the scenarios of a state (existing, removed, included).
```
test_resolve.py::TestResolve::test_build_state PASSED                    [100%]
```